### PR TITLE
Remove internal map for queue indexes. Use the underlying medium to d…

### DIFF
--- a/src/main/kotlin/au/kilemon/messagequeue/configuration/QueueConfiguration.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/configuration/QueueConfiguration.kt
@@ -70,16 +70,6 @@ class QueueConfiguration : HasLogger
             }
         }
 
-        if (!messageQueueSettings.multiQueueLazyInitialise.toBoolean())
-        {
-            LOG.trace("Lazy initialising is disabled, initialising queue indexes for existing messages now.")
-            queue.initialiseQueueIndex()
-        }
-        else
-        {
-            LOG.debug("Lazy initialise enabled with provided argument [{}], delaying initialisation.", messageQueueSettings.multiQueueLazyInitialise)
-        }
-
         LOG.info("Initialising [{}] queue as the [{}] is set to [{}].", queue::class.java.name, MessageQueueSettings.MULTI_QUEUE_TYPE, messageQueueSettings.multiQueueType)
 
         return queue

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/repository/MongoQueueMessageRepository.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/repository/MongoQueueMessageRepository.kt
@@ -55,4 +55,11 @@ interface MongoQueueMessageRepository: MongoRepository<QueueMessageDocument, Lon
      */
     @Modifying
     fun deleteByUuid(uuid: String): Int
+
+    /**
+     * Get the entry with the largest ID.
+     *
+     * @return the [QueueMessageDocument] with the largest ID, otherwise [Optional.empty]
+     */
+    fun findTopByOrderByIdDesc(): Optional<QueueMessageDocument>
 }

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
@@ -26,26 +26,6 @@ class SqlMultiQueue : MultiQueue, HasLogger
     @Autowired
     private lateinit var queueMessageRepository: SQLQueueMessageRepository
 
-    override var maxQueueIndex: HashMap<String, AtomicLong>? = null
-
-    override fun getMaxQueueMap(): HashMap<String, AtomicLong>
-    {
-        if (maxQueueIndex == null)
-        {
-            initialiseQueueIndex()
-        }
-
-        return maxQueueIndex!!
-    }
-
-    /**
-     * Just initialise map, so it's not null, but the SQL [QueueMessage] ID is maintained by the database.
-     */
-    override fun initialiseQueueIndex()
-    {
-        maxQueueIndex = HashMap()
-    }
-
     override fun getQueueForType(queueType: String): Queue<QueueMessage>
     {
         val entries = queueMessageRepository.findByTypeOrderByIdAsc(queueType)
@@ -172,7 +152,7 @@ class SqlMultiQueue : MultiQueue, HasLogger
      * Overriding to return [Optional.EMPTY] so that the [MultiQueue.add] does set an `id` into the [QueueMessage]
      * even if the id is `null`.
      */
-    override fun getAndIncrementQueueIndex(queueType: String): Optional<Long>
+    override fun getNextQueueIndex(queueType: String): Optional<Long>
     {
         return Optional.empty()
     }

--- a/src/main/kotlin/au/kilemon/messagequeue/settings/MessageQueueSettings.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/settings/MessageQueueSettings.kt
@@ -28,7 +28,6 @@ class MessageQueueSettings
     {
         const val MULTI_QUEUE_TYPE: String = "MULTI_QUEUE_TYPE"
         const val MULTI_QUEUE_TYPE_DEFAULT: String = "IN_MEMORY"
-        const val MULTI_QUEUE_LAZY_INITIALISE: String = "MULTI_QUEUE_LAZY_INITIALISE"
 
         /**
          * Start redis related properties
@@ -79,18 +78,6 @@ class MessageQueueSettings
     @get:Generated
     @set:Generated
     lateinit var multiQueueType: String
-
-    /**
-     * `Optional` uses the [MULTI_QUEUE_TYPE] environment variable to determine where
-     * the underlying multi queue is persisted. It can be any value of [MultiQueueType].
-     * Defaults to [MultiQueueType.IN_MEMORY] ([MULTI_QUEUE_TYPE_DEFAULT]).
-     */
-    @SerializedName(MULTI_QUEUE_LAZY_INITIALISE)
-    @JsonProperty(MULTI_QUEUE_LAZY_INITIALISE)
-    @Value("\${$MULTI_QUEUE_LAZY_INITIALISE:false}")
-    @get:Generated
-    @set:Generated
-    lateinit var multiQueueLazyInitialise: String
 
 
     /**

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMockMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMockMultiQueueTest.kt
@@ -18,12 +18,6 @@ class InMemoryMockMultiQueueTest
 {
     private val multiQueue: InMemoryMultiQueue = Mockito.spy(InMemoryMultiQueue::class.java)
 
-    @BeforeEach
-    fun setUp()
-    {
-        multiQueue.initialiseQueueIndex()
-    }
-
     /**
      * Test [InMemoryMultiQueue.add] to ensure that `false` is returned when [InMemoryMultiQueue.addInternal] returns `false`.
      */

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/MongoMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/MongoMultiQueueTest.kt
@@ -28,7 +28,7 @@ import org.testcontainers.utility.DockerImageName
  */
 @ExtendWith(SpringExtension::class)
 @Testcontainers
-@DataMongoTest(properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=MONGO", "${MessageQueueSettings.MULTI_QUEUE_LAZY_INITIALISE}=true"])
+@DataMongoTest(properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=MONGO"])
 @ContextConfiguration(initializers = [MongoMultiQueueTest.Initializer::class])
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import( *[QueueConfiguration::class, LoggingConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class] )
@@ -103,6 +103,5 @@ class MongoMultiQueueTest: AbstractMultiQueueTest()
     {
         Assertions.assertTrue(mongoDb.isRunning)
         multiQueue.clear()
-        multiQueue.getMaxQueueMap()
     }
 }

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerMockTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerMockTest.kt
@@ -77,7 +77,6 @@ class MessageQueueControllerMockTest
     fun testCreateMessage_addFails()
     {
         val message = QueueMessage("payload", "type")
-        multiQueue.initialiseQueueIndex()
 
         Mockito.`when`(multiQueue.add(message)).thenReturn(false)
 

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/SettingsControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/SettingsControllerTest.kt
@@ -68,7 +68,6 @@ class SettingsControllerTest
         val settings = gson.fromJson(mvcResult.response.contentAsString, MessageQueueSettings::class.java)
 
         Assertions.assertEquals(MultiQueueType.IN_MEMORY.toString(), settings.multiQueueType)
-        Assertions.assertEquals("false", settings.multiQueueLazyInitialise)
 
         Assertions.assertTrue(settings.redisPrefix.isEmpty())
         Assertions.assertEquals(MessageQueueSettings.REDIS_ENDPOINT_DEFAULT, settings.redisEndpoint)


### PR DESCRIPTION
…etermine the next index. So that multiple MultiQueue instances could be used together.