### PR TITLE
Introduce MessageListResponse so that correlationIds are not duplicat…

### DIFF
--- a/src/main/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueController.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueController.kt
@@ -7,6 +7,7 @@ import au.kilemon.messagequeue.queue.MultiQueue
 import au.kilemon.messagequeue.queue.cache.redis.RedisMultiQueue
 import au.kilemon.messagequeue.queue.exception.DuplicateMessageException
 import au.kilemon.messagequeue.queue.exception.HealthCheckFailureException
+import au.kilemon.messagequeue.rest.response.MessageListResponse
 import au.kilemon.messagequeue.rest.response.MessageResponse
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.Operation
@@ -368,14 +369,13 @@ open class MessageQueueController : HasLogger
     fun getOwned(@Parameter(`in` = ParameterIn.QUERY, required = true, description = "The identifier that must match the message's `assigned` property in order to be returned.")
                  @RequestParam(required = true, name = RestParameters.ASSIGNED_TO) assignedTo: String,
                  @Parameter(`in` = ParameterIn.QUERY, required = true, description = "The sub-queue to search for the assigned messages.")
-                 @RequestParam(required = true, name = RestParameters.SUB_QUEUE) subQueue: String): ResponseEntity<List<MessageResponse>>
+                 @RequestParam(required = true, name = RestParameters.SUB_QUEUE) subQueue: String): ResponseEntity<MessageListResponse>
     {
         authenticator.canAccessSubQueue(subQueue)
 
         val assignedMessages: Queue<QueueMessage> = messageQueue.getAssignedMessagesInSubQueue(subQueue, assignedTo)
-        val ownedMessages = assignedMessages.stream().map { message -> MessageResponse(message) }.collect(Collectors.toList())
-        LOG.debug("Found [{}] owned entries within sub-queue [{}] for user with identifier [{}].", ownedMessages.size, subQueue, assignedTo)
-        return ResponseEntity.ok(ownedMessages)
+        LOG.debug("Found [{}] owned entries within sub-queue [{}] for user with identifier [{}].", assignedMessages.size, subQueue, assignedTo)
+        return ResponseEntity.ok(MessageListResponse(assignedMessages.stream().toList()))
     }
 
     /**

--- a/src/main/kotlin/au/kilemon/messagequeue/rest/response/MessageListResponse.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/rest/response/MessageListResponse.kt
@@ -2,30 +2,27 @@ package au.kilemon.messagequeue.rest.response
 
 import au.kilemon.messagequeue.filter.CorrelationIdFilter
 import au.kilemon.messagequeue.message.QueueMessage
-import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import io.swagger.v3.oas.annotations.media.Schema
 import org.slf4j.MDC
 
 /**
- * A response object which wraps the [QueueMessage].
+ * Response object used when multiple messages are being returned.
  *
  * @author github.com/Kilemonn
  */
-@JsonPropertyOrder("correlationId", "message")
-class MessageResponse
-{
+class MessageListResponse {
     @Schema(title = "The request correlation ID.", example = "1599dcd3-7424-4f97-bc99-b9b3e5c53d59",
         description = "A UUID that uniquely identifies the performed request. This will correlate with any logs written as part of this request for debugging purposes.")
     val correlationId: String? = MDC.get(CorrelationIdFilter.CORRELATION_ID)
 
-    @Schema(description = "The retrieved or created QueueMessage.")
-    val message: QueueMessage
+    @Schema(description = "The retrieved or created QueueMessages.")
+    val messages: List<QueueMessage>
 
     /**
      * Not converting to primary constructor, so we can use [Schema] annotations.
      */
-    constructor(message: QueueMessage)
+    constructor(messages: List<QueueMessage>)
     {
-        this.message = message
+        this.messages = messages
     }
 }

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
@@ -11,6 +11,7 @@ import au.kilemon.messagequeue.message.QueueMessage
 import au.kilemon.messagequeue.queue.MultiQueue
 import au.kilemon.messagequeue.rest.model.Payload
 import au.kilemon.messagequeue.rest.model.PayloadEnum
+import au.kilemon.messagequeue.rest.response.MessageListResponse
 import au.kilemon.messagequeue.rest.response.MessageResponse
 import au.kilemon.messagequeue.settings.MessageQueueSettings
 import com.google.gson.Gson
@@ -627,9 +628,8 @@ class MessageQueueControllerTest
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn()
 
-        val listType = object : TypeToken<List<MessageResponse>>() {}.type
-        val owned = gson.fromJson<List<MessageResponse>>(mvcResult.response.contentAsString, listType)
-        Assertions.assertTrue(owned.isEmpty())
+        val owned = gson.fromJson<MessageListResponse>(mvcResult.response.contentAsString, MessageListResponse::class.java)
+        Assertions.assertTrue(owned.messages.isEmpty())
     }
 
     /**
@@ -656,13 +656,12 @@ class MessageQueueControllerTest
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn()
 
-        val listType = object : TypeToken<List<MessageResponse>>() {}.type
-        val owned = gson.fromJson<List<MessageResponse>>(mvcResult.response.contentAsString, listType)
-        Assertions.assertTrue(owned.isNotEmpty())
-        owned.forEach { message ->
-            Assertions.assertTrue(message.message.uuid == message1.uuid || message.message.uuid == message2.uuid)
-            Assertions.assertEquals(subQueue, message.message.subQueue)
-            Assertions.assertEquals(assignedTo, message.message.assignedTo)
+        val owned = gson.fromJson<MessageListResponse>(mvcResult.response.contentAsString, MessageListResponse::class.java)
+        Assertions.assertTrue(owned.messages.isNotEmpty())
+        owned.messages.forEach { message ->
+            Assertions.assertTrue(message.uuid == message1.uuid || message.uuid == message2.uuid)
+            Assertions.assertEquals(subQueue, message.subQueue)
+            Assertions.assertEquals(assignedTo, message.assignedTo)
         }
     }
 
@@ -704,13 +703,12 @@ class MessageQueueControllerTest
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andReturn()
 
-        val listType = object : TypeToken<List<MessageResponse>>() {}.type
-        val owned = gson.fromJson<List<MessageResponse>>(mvcResult.response.contentAsString, listType)
-        Assertions.assertTrue(owned.isNotEmpty())
-        owned.forEach { message ->
-            Assertions.assertTrue(message.message.uuid == message1.uuid || message.message.uuid == message2.uuid)
-            Assertions.assertEquals(subQueue, message.message.subQueue)
-            Assertions.assertEquals(assignedTo, message.message.assignedTo)
+        val owned = gson.fromJson<MessageListResponse>(mvcResult.response.contentAsString, MessageListResponse::class.java)
+        Assertions.assertTrue(owned.messages.isNotEmpty())
+        owned.messages.forEach { message ->
+            Assertions.assertTrue(message.uuid == message1.uuid || message.uuid == message2.uuid)
+            Assertions.assertEquals(subQueue, message.subQueue)
+            Assertions.assertEquals(assignedTo, message.assignedTo)
         }
     }
 


### PR DESCRIPTION
…ed for each message (since it would all be the same id) but only once in the body of the response.