### PR TITLE
Change queue message id number to UUID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 group = "au.kilemon"
 // Make sure version matches version defined in MessageQueueApplication
-version = "0.4.3"
+version = "0.5.0"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {

--- a/src/main/kotlin/au/kilemon/messagequeue/MessageQueueApplication.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/MessageQueueApplication.kt
@@ -17,7 +17,7 @@ open class MessageQueueApplication
         /**
          * Application version number, make sure this matches what is defined in `build.gradle.kts`.
          */
-        const val VERSION: String = "0.4.3"
+        const val VERSION: String = "0.5.0"
     }
 }
 

--- a/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessage.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessage.kt
@@ -1,18 +1,17 @@
 package au.kilemon.messagequeue.message
 
+import au.kilemon.messagequeue.rest.controller.model.CreateMessage
 import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.Lob
 import jakarta.persistence.Table
 import jakarta.persistence.Transient
 import org.springframework.util.SerializationUtils
 import java.io.Serializable
-import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 
 /**
@@ -52,15 +51,12 @@ class QueueMessage: Serializable
             payloadBytes = SerializationUtils.serialize(payload)
         }
 
-    @Schema(title = "Message unique identifier", example = "7a3c1326-f038-4c17-9b6b-a9ada353f79c",
+    @Id
+    @OptIn(ExperimentalUuidApi::class)
+    @Schema(title = "Message unique identifier", example = "019e2102-e818-7312-a5d7-8cf1d66e0420",
         description = "A unique identifier for this message, usually in the form of a UUID, unless created otherwise. This can be used to directly retireve or manipulate the message.")
     @Column(nullable = false, unique = true)
-    var uuid: String = UUID.randomUUID().toString()
-
-    @JsonIgnore
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null
+    var uuid: String = Uuid.generateV7().toString()
 
     @JsonIgnore
     // @Lob - Needed to remove to support SQLLite, seems like it was not required
@@ -83,9 +79,15 @@ class QueueMessage: Serializable
     {
         this.subQueue = queueMessageDocument.subQueue
         this.uuid = queueMessageDocument.uuid
-        this.id = queueMessageDocument.id
         this.payload = queueMessageDocument.payload
         this.assignedTo = queueMessageDocument.assignedTo
+    }
+
+    constructor(createMessage: CreateMessage) : this()
+    {
+        this.subQueue = createMessage.subQueue
+        this.payload = createMessage.payload
+        this.assignedTo = createMessage.assignedTo
     }
 
     /**
@@ -158,7 +160,7 @@ class QueueMessage: Serializable
      */
     override fun hashCode(): Int {
         var result = payload?.hashCode() ?: 0
-        result = 31 * result + (payloadBytes?.hashCode() ?: 0)
+        result = 31 * result + (payloadBytes?.contentHashCode() ?: 0)
         result = 31 * result + subQueue.hashCode()
         result = 31 * result + uuid.hashCode()
         return result

--- a/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessageDocument.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessageDocument.kt
@@ -1,9 +1,9 @@
 package au.kilemon.messagequeue.message
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import org.springframework.data.annotation.Id
 import org.springframework.data.mongodb.core.mapping.Document
-import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 
 /**
@@ -19,11 +19,9 @@ class QueueMessageDocument(var payload: Any?, var subQueue: String, var assigned
         const val DOCUMENT_NAME: String = "multiqueuemessages"
     }
 
-    var uuid: String = UUID.randomUUID().toString()
-
-    @JsonIgnore
     @Id
-    var id: Long? = null
+    @OptIn(ExperimentalUuidApi::class)
+    var uuid: String = Uuid.generateV7().toString()
 
     /**
      * Required for JSON deserialisation.
@@ -35,7 +33,6 @@ class QueueMessageDocument(var payload: Any?, var subQueue: String, var assigned
         val resolvedQueueMessage = queueMessage.resolvePayloadObject()
         this.subQueue = resolvedQueueMessage.subQueue
         this.uuid = resolvedQueueMessage.uuid
-        this.id = resolvedQueueMessage.id
         this.payload = resolvedQueueMessage.payload
         this.assignedTo = resolvedQueueMessage.assignedTo
     }

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/MultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/MultiQueue.kt
@@ -51,18 +51,6 @@ abstract class MultiQueue: Queue<QueueMessage>, HasLogger
         }
 
     /**
-     * Get the next queue index.
-     * If it does not exist yet, a default value of 1 will be set and returned.
-     *
-     * This can be overridden to return [Optional.EMPTY] to not override the ID of the
-     * incoming messages even if it is empty as it is maintained by the underlying mechanism
-     * (in most cases a database).
-     *
-     * @return the current value of the index before it was incremented
-     */
-    abstract fun getNextSubQueueIndex(subQueue: String): Optional<Long>
-
-    /**
      * A wrapper for the [MultiQueue.persistMessageInternal] so this method can be synchronised.
      *
      * Synchronising so that multiple messages are not updated out of order.
@@ -407,14 +395,6 @@ abstract class MultiQueue: Queue<QueueMessage>, HasLogger
         val subQueueMessageAlreadyExistsIn = containsUUID(element.uuid)
         if ( !subQueueMessageAlreadyExistsIn.isPresent)
         {
-            if (element.id == null)
-            {
-                val index = getNextSubQueueIndex(element.subQueue)
-                if (index.isPresent)
-                {
-                    element.id = index.get()
-                }
-            }
             val wasAdded = addInternal(element)
             return if (wasAdded)
             {

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisMultiQueue.kt
@@ -84,7 +84,7 @@ class RedisMultiQueue(private val prefix: String = "", private val redisTemplate
         val set = redisTemplate.opsForSet().members(appendPrefix(subQueue))
         if (!set.isNullOrEmpty())
         {
-            queue.addAll(set.toSortedSet { message1, message2 -> (message1.id ?: 0).minus(message2.id ?: 0).toInt() })
+            queue.addAll(set.sortedBy { it.uuid })
         }
         return queue
     }
@@ -129,34 +129,6 @@ class RedisMultiQueue(private val prefix: String = "", private val redisTemplate
     {
         val result = redisTemplate.opsForSet().add(appendPrefix(element.subQueue), element)
         return result != null && result > 0
-    }
-
-    /**
-     * Overriding to pass in the [subQueue] into [appendPrefix].
-     */
-    override fun getNextSubQueueIndex(subQueue: String): Optional<Long>
-    {
-        val queue = getSubQueue(appendPrefix(subQueue))
-        return if (queue.isNotEmpty())
-        {
-            var lastIndex = queue.last().id
-            if (lastIndex == null)
-            {
-                LOG.warn("subQueue [{}] is not empty but last index is null. Returning index with value [{}].", subQueue, 1)
-                return Optional.of(1)
-            }
-            else
-            {
-                lastIndex++
-                LOG.trace("Incrementing and returning index for subQueue [{}]. Returning index with value [{}].", subQueue, lastIndex)
-                return Optional.of(lastIndex)
-            }
-        }
-        else
-        {
-            LOG.trace("subQueue [{}] is empty, returning index with value [{}].", subQueue, 1)
-            Optional.of(1)
-        }
     }
 
     override fun removeInternal(element: QueueMessage): Boolean
@@ -247,11 +219,9 @@ class RedisMultiQueue(private val prefix: String = "", private val redisTemplate
      */
     override fun persistMessageInternal(message: QueueMessage)
     {
-        val queue = getSubQueue(message.subQueue)
-        val matchingMessage = queue.stream().filter{ element -> element.uuid == message.uuid }.findFirst()
+        val matchingMessage = getMessageByUUID(message.uuid)
         if (matchingMessage.isPresent)
         {
-            message.id = matchingMessage.get().id
             val wasRemoved = removeInternal(matchingMessage.get())
             val wasReAdded = addInternal(message)
             if (wasRemoved && wasReAdded)

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueue.kt
@@ -36,22 +36,6 @@ open class InMemoryMultiQueue : MultiQueue(), HasLogger
 
     private val maxQueueIndex: HashMap<String, AtomicLong> = HashMap()
 
-    /**
-     * This index is special compared to the other [au.kilemon.messagequeue.settings.StorageMedium] it will be incremented once retrieved.
-     * So we could be skipping indexes, but it should be fine since it's only used for message ordering.
-     */
-    override fun getNextSubQueueIndex(subQueue: String): Optional<Long>
-    {
-        var index = maxQueueIndex[subQueue]
-        if (index == null)
-        {
-            index = AtomicLong(1)
-            maxQueueIndex[subQueue] = index
-            LOG.trace("Creating new index for subQueue [{}], index starting at [{}].", subQueue, index)
-        }
-        return Optional.of(index.getAndIncrement())
-    }
-
     override fun getSubQueueInternal(subQueue: String): Queue<QueueMessage>
     {
         var queue: Queue<QueueMessage>? = messageQueue[subQueue]

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/MongoMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/MongoMultiQueue.kt
@@ -22,11 +22,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
  */
 class MongoMultiQueue : MultiQueue(), HasLogger
 {
-    companion object
-    {
-        const val INDEX_ID = "index_id"
-    }
-
     override val LOG: Logger = this.initialiseLogger()
 
     @Lazy
@@ -35,15 +30,13 @@ class MongoMultiQueue : MultiQueue(), HasLogger
 
     override fun persistMessageInternal(message: QueueMessage)
     {
-        val queueMessageDocument = QueueMessageDocument(message)
-        try
+        if (queueMessageRepository.findByUuid(message.uuid).isPresent)
         {
+            val queueMessageDocument = QueueMessageDocument(message)
             queueMessageRepository.save(queueMessageDocument)
+            return
         }
-        catch (ex: Exception)
-        {
-            throw MessageUpdateException(message.uuid, ex)
-        }
+        throw MessageUpdateException(message.uuid)
     }
 
     /**
@@ -53,11 +46,11 @@ class MongoMultiQueue : MultiQueue(), HasLogger
     {
         val entries = if (assignedTo == null)
         {
-            queueMessageRepository.findBySubQueueAndAssignedToIsNotNullOrderByIdAsc(subQueue)
+            queueMessageRepository.findBySubQueueAndAssignedToIsNotNullOrderByUuidAsc(subQueue)
         }
         else
         {
-            queueMessageRepository.findBySubQueueAndAssignedToOrderByIdAsc(subQueue, assignedTo)
+            queueMessageRepository.findBySubQueueAndAssignedToOrderByUuidAsc(subQueue, assignedTo)
         }
 
         return ConcurrentLinkedQueue(entries.map { entry -> QueueMessage(entry) })
@@ -68,13 +61,13 @@ class MongoMultiQueue : MultiQueue(), HasLogger
      */
     override fun getUnassignedMessagesInSubQueue(subQueue: String): Queue<QueueMessage>
     {
-        val entries = queueMessageRepository.findBySubQueueAndAssignedToIsNullOrderByIdAsc(subQueue)
+        val entries = queueMessageRepository.findBySubQueueAndAssignedToIsNullOrderByUuidAsc(subQueue)
         return ConcurrentLinkedQueue(entries.map { entry -> QueueMessage(entry) })
     }
 
     override fun getSubQueueInternal(subQueue: String): Queue<QueueMessage>
     {
-        val entries = queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue)
+        val entries = queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue)
         return ConcurrentLinkedQueue(entries.map { entry -> QueueMessage(entry) })
     }
 
@@ -107,12 +100,12 @@ class MongoMultiQueue : MultiQueue(), HasLogger
 
     override fun isEmptySubQueue(subQueue: String): Boolean
     {
-        return queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue).isEmpty()
+        return queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue).isEmpty()
     }
 
     override fun pollInternal(subQueue: String): Optional<QueueMessage>
     {
-        val messages = queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue)
+        val messages = queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue)
         return if (messages.isNotEmpty())
         {
             return Optional.of(QueueMessage(messages[0]))
@@ -152,41 +145,21 @@ class MongoMultiQueue : MultiQueue(), HasLogger
     override fun addInternal(element: QueueMessage): Boolean
     {
         val queueMessageDocument = QueueMessageDocument(element)
-        val saved = queueMessageRepository.save(queueMessageDocument)
-        return saved.id != null
+        try
+        {
+            queueMessageRepository.save(queueMessageDocument)
+            return true
+        }
+        catch (ex: Exception)
+        {
+            LOG.error("Failed to add message to sub queue [{}]", element.subQueue, ex)
+            return false
+        }
     }
 
     override fun removeInternal(element: QueueMessage): Boolean
     {
         val removedCount = queueMessageRepository.deleteByUuid(element.uuid)
         return removedCount > 0
-    }
-
-    /**
-     * Overriding to use the constant [INDEX_ID] for all look-ups since the ID is shared and needs to be assigned to
-     * the [QueueMessageDocument] before it is created.
-     */
-    override fun getNextSubQueueIndex(subQueue: String): Optional<Long>
-    {
-        val largestIdMessage = queueMessageRepository.findTopByOrderByIdDesc()
-        return if (largestIdMessage.isPresent)
-        {
-            var lastIndex = largestIdMessage.get().id
-            if (lastIndex == null)
-            {
-                LOG.warn("subQueue [{}] is not empty but last index is null. Returning index with value [{}].", subQueue, 1)
-                return Optional.of(1)
-            }
-            else
-            {
-                lastIndex++
-                LOG.trace("Incrementing and returning index for subQueue [{}]. Returning index with value [{}].", subQueue, lastIndex)
-                return Optional.of(lastIndex)
-            }
-        }
-        else
-        {
-            Optional.of(1)
-        }
     }
 }

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/repository/MongoQueueMessageRepository.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/nosql/mongo/repository/MongoQueueMessageRepository.kt
@@ -25,12 +25,12 @@ interface MongoQueueMessageRepository: MongoRepository<QueueMessageDocument, Lon
     fun getDistinctSubQueues(): List<String>
 
     /**
-     * Get a list of [QueueMessageDocument] which have [QueueMessageDocument.subQueue] matching the provided [subQueue].
+     * Get a list of [QueueMessageDocument] which have [QueueMessageDocument.subQueue] matching the provided [subQueue]. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessageDocument.subQueue] with
      * @return a [List] of [QueueMessageDocument] who have a matching [QueueMessageDocument.subQueue] with the provided [subQueue]
      */
-    fun findBySubQueueOrderByIdAsc(subQueue: String): List<QueueMessageDocument>
+    fun findBySubQueueOrderByUuidAsc(subQueue: String): List<QueueMessageDocument>
 
     /**
      * Find and return a [QueueMessageDocument] that matches the provided [uuid].
@@ -59,37 +59,30 @@ interface MongoQueueMessageRepository: MongoRepository<QueueMessageDocument, Lon
     fun deleteByUuid(uuid: String): Int
 
     /**
-     * Get the entry with the largest ID.
-     *
-     * @return the [QueueMessageDocument] with the largest ID, otherwise [Optional.empty]
-     */
-    fun findTopByOrderByIdDesc(): Optional<QueueMessageDocument>
-
-    /**
-     * Find the entity with the matching [QueueMessageDocument.subQueue] and that has a non-null [QueueMessageDocument.assignedTo]. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessageDocument.subQueue] and that has a non-null [QueueMessageDocument.assignedTo]. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessageDocument.subQueue] with
      * @return a [List] of [QueueMessageDocument] who have a matching [QueueMessageDocument.subQueue] with the provided [subQueue] and non-null [QueueMessageDocument.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToIsNotNullOrderByIdAsc(subQueue: String): List<QueueMessageDocument>
+    fun findBySubQueueAndAssignedToIsNotNullOrderByUuidAsc(subQueue: String): List<QueueMessageDocument>
 
     /**
-     * Find the entity with the matching [QueueMessageDocument.subQueue] and [QueueMessageDocument.assignedTo]. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessageDocument.subQueue] and [QueueMessageDocument.assignedTo]. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessageDocument.subQueue] with
      * @param assignedTo the identifier to match [QueueMessageDocument.assignedTo] with
      * @return a [List] of [QueueMessageDocument] who have a matching [QueueMessageDocument.subQueue] and [QueueMessageDocument.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToOrderByIdAsc(subQueue: String, assignedTo: String): List<QueueMessageDocument>
+    fun findBySubQueueAndAssignedToOrderByUuidAsc(subQueue: String, assignedTo: String): List<QueueMessageDocument>
 
     /**
-     * Find the entity with the matching [QueueMessageDocument.subQueue] and that has [QueueMessageDocument.assignedTo] set to `null`. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessageDocument.subQueue] and that has [QueueMessageDocument.assignedTo] set to `null`. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessageDocument.subQueue] with
      * @return a [List] of [QueueMessageDocument] who have a matching [QueueMessageDocument.subQueue] with the provided [subQueue] and `null` [QueueMessageDocument.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToIsNullOrderByIdAsc(subQueue: String): List<QueueMessageDocument>
+    fun findBySubQueueAndAssignedToIsNullOrderByUuidAsc(subQueue: String): List<QueueMessageDocument>
 }

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
@@ -29,7 +29,7 @@ class SqlMultiQueue : MultiQueue(), HasLogger
 
     override fun getSubQueueInternal(subQueue: String): Queue<QueueMessage>
     {
-        val entries = queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue)
+        val entries = queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue)
         return ConcurrentLinkedQueue(entries.map { entry -> entry.resolvePayloadObject() })
     }
 
@@ -40,11 +40,11 @@ class SqlMultiQueue : MultiQueue(), HasLogger
     {
         val entries = if (assignedTo == null)
         {
-            queueMessageRepository.findBySubQueueAndAssignedToIsNotNullOrderByIdAsc(subQueue)
+            queueMessageRepository.findBySubQueueAndAssignedToIsNotNullOrderByUuidAsc(subQueue)
         }
         else
         {
-            queueMessageRepository.findBySubQueueAndAssignedToOrderByIdAsc(subQueue, assignedTo)
+            queueMessageRepository.findBySubQueueAndAssignedToOrderByUuidAsc(subQueue, assignedTo)
         }
 
         return ConcurrentLinkedQueue(entries.map { entry -> entry.resolvePayloadObject() })
@@ -55,7 +55,7 @@ class SqlMultiQueue : MultiQueue(), HasLogger
      */
     override fun getUnassignedMessagesInSubQueue(subQueue: String): Queue<QueueMessage>
     {
-        val entries = queueMessageRepository.findBySubQueueAndAssignedToIsNullOrderByIdAsc(subQueue)
+        val entries = queueMessageRepository.findBySubQueueAndAssignedToIsNullOrderByUuidAsc(subQueue)
         return ConcurrentLinkedQueue(entries.map { entry -> entry.resolvePayloadObject() })
     }
 
@@ -88,12 +88,12 @@ class SqlMultiQueue : MultiQueue(), HasLogger
 
     override fun isEmptySubQueue(subQueue: String): Boolean
     {
-        return queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue).isEmpty()
+        return queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue).isEmpty()
     }
 
     override fun pollInternal(subQueue: String): Optional<QueueMessage>
     {
-        val messages = queueMessageRepository.findBySubQueueOrderByIdAsc(subQueue)
+        val messages = queueMessageRepository.findBySubQueueOrderByUuidAsc(subQueue)
         return if (messages.isNotEmpty())
         {
             return Optional.of(messages[0].resolvePayloadObject())
@@ -134,8 +134,16 @@ class SqlMultiQueue : MultiQueue(), HasLogger
     {
         // UUID Unique constraint ensures we don't save duplicate entries
         // Not need to set [QueueMessage.id] since it's managed by the DB
-        val saved = queueMessageRepository.save(element)
-        return saved.id != null
+        try
+        {
+            queueMessageRepository.save(element)
+            return true
+        }
+        catch (ex: Exception)
+        {
+            LOG.error("Failed to add entry to subqueue [{}]", element.subQueue, ex)
+            return false
+        }
     }
 
     override fun removeInternal(element: QueueMessage): Boolean
@@ -146,25 +154,12 @@ class SqlMultiQueue : MultiQueue(), HasLogger
 
     override fun persistMessageInternal(message: QueueMessage)
     {
-        // We are working with an object from JPA if there is an existing ID
-        // If there is no id in the provided message then we will check that the message with the same UUID does exist
-        if (message.id != null || queueMessageRepository.findByUuid(message.uuid).isPresent)
+        // If there is no existing message we are not persisting or updating in place and need to throw
+        if (queueMessageRepository.findByUuid(message.uuid).isPresent)
         {
-            val saved = queueMessageRepository.save(message)
-            if (saved == message)
-            {
-                return
-            }
+            queueMessageRepository.save(message)
+            return
         }
         throw MessageUpdateException(message.uuid)
-    }
-
-    /**
-     * Overriding to return [Optional.EMPTY] so that the [MultiQueue.add] does set an `id` into the [QueueMessage]
-     * even if the id is `null`.
-     */
-    override fun getNextSubQueueIndex(subQueue: String): Optional<Long>
-    {
-        return Optional.empty()
     }
 }

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/sql/repository/SqlQueueMessageRepository.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/sql/repository/SqlQueueMessageRepository.kt
@@ -41,41 +41,41 @@ interface SqlQueueMessageRepository: JpaRepository<QueueMessage, Long>
     fun findDistinctSubQueue(): List<String>
 
     /**
-     * Get a list of [QueueMessage] which have [QueueMessage.subQueue] matching the provided [subQueue].
+     * Get a list of [QueueMessage] which have [QueueMessage.subQueue] matching the provided [subQueue]. Sorted by UUID ascending.
      *
      * @param subQueue to match [QueueMessage.subQueue] with
      * @return a [List] of [QueueMessage] who have a matching [QueueMessage.subQueue] with the provided [subQueue]
      */
     @Transactional
-    fun findBySubQueueOrderByIdAsc(subQueue: String): List<QueueMessage>
+    fun findBySubQueueOrderByUuidAsc(subQueue: String): List<QueueMessage>
 
     /**
-     * Find the entity with the matching [QueueMessage.subQueue] and that has a non-null [QueueMessage.assignedTo]. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessage.subQueue] and that has a non-null [QueueMessage.assignedTo]. Sorted by UUID ascending.
      *
      * @param subQueue to match [QueueMessage.subQueue] with
      * @return a [List] of [QueueMessage] who have a matching [QueueMessage.subQueue] with the provided [subQueue] and non-null [QueueMessage.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToIsNotNullOrderByIdAsc(subQueue: String): List<QueueMessage>
+    fun findBySubQueueAndAssignedToIsNotNullOrderByUuidAsc(subQueue: String): List<QueueMessage>
 
     /**
-     * Find the entity with the matching [QueueMessage.subQueue] and that has [QueueMessage.assignedTo] set to `null`. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessage.subQueue] and that has [QueueMessage.assignedTo] set to `null`. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessage.subQueue] with
      * @return a [List] of [QueueMessage] who have a matching [QueueMessage.subQueue] with the provided [subQueue] and `null` [QueueMessage.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToIsNullOrderByIdAsc(subQueue: String): List<QueueMessage>
+    fun findBySubQueueAndAssignedToIsNullOrderByUuidAsc(subQueue: String): List<QueueMessage>
 
     /**
-     * Find the entity with the matching [QueueMessage.subQueue] and [QueueMessage.assignedTo]. Sorted by ID ascending.
+     * Find the entity with the matching [QueueMessage.subQueue] and [QueueMessage.assignedTo]. Sorted by UUID ascending.
      *
      * @param subQueue the type to match [QueueMessage.subQueue] with
      * @param assignedTo the identifier to match [QueueMessage.assignedTo] with
      * @return a [List] of [QueueMessage] who have a matching [QueueMessage.subQueue] and [QueueMessage.assignedTo]
      */
     @Transactional
-    fun findBySubQueueAndAssignedToOrderByIdAsc(subQueue: String, assignedTo: String): List<QueueMessage>
+    fun findBySubQueueAndAssignedToOrderByUuidAsc(subQueue: String, assignedTo: String): List<QueueMessage>
 
     /**
      * Find the entity which has a [QueueMessage.uuid] matching the provided [uuid].

--- a/src/main/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueController.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueController.kt
@@ -7,6 +7,7 @@ import au.kilemon.messagequeue.queue.MultiQueue
 import au.kilemon.messagequeue.queue.cache.redis.RedisMultiQueue
 import au.kilemon.messagequeue.queue.exception.DuplicateMessageException
 import au.kilemon.messagequeue.queue.exception.HealthCheckFailureException
+import au.kilemon.messagequeue.rest.controller.model.CreateMessage
 import au.kilemon.messagequeue.rest.response.KeysResponse
 import au.kilemon.messagequeue.rest.response.MessageListResponse
 import au.kilemon.messagequeue.rest.response.MessageResponse
@@ -216,17 +217,19 @@ open class MessageQueueController : HasLogger
         ApiResponse(responseCode = "409", description = "A queue message already exists with the same UUID.", content = [Content()]), // Add empty Content() to remove duplicate responses in swagger docs
         ApiResponse(responseCode = "500", description = "An internal system error occurred when adding the new queue message.", content = [Content()])
     )
-    fun createMessage(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "The new queue message to create in the multi queue.") @Valid @RequestBody queueMessage: QueueMessage): ResponseEntity<MessageResponse>
+    fun createMessage(@io.swagger.v3.oas.annotations.parameters.RequestBody(required = true, description = "The new queue message to create in the multi queue.") @Valid @RequestBody createMessage: CreateMessage): ResponseEntity<MessageResponse>
     {
+
+        authenticator.canAccessSubQueue(createMessage.subQueue)
+
+        if (createMessage.assignedTo != null && createMessage.assignedTo!!.isBlank())
+        {
+            createMessage.assignedTo = null
+        }
+
+        val queueMessage = QueueMessage(createMessage)
         try
         {
-            authenticator.canAccessSubQueue(queueMessage.subQueue)
-
-            if (queueMessage.assignedTo != null && queueMessage.assignedTo!!.isBlank())
-            {
-                queueMessage.assignedTo = null
-            }
-
             val wasAdded = messageQueue.add(queueMessage)
             if (wasAdded)
             {

--- a/src/main/kotlin/au/kilemon/messagequeue/rest/controller/model/CreateMessage.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/rest/controller/model/CreateMessage.kt
@@ -1,0 +1,25 @@
+package au.kilemon.messagequeue.rest.controller.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * A model used during the message create request so we are able to only expose and allow the user to set fields we allow.
+ * Specifically we do not want the user to be able to provide their own UUID anymore, since it must be a v7 UUID that we generate.
+ *
+ * @author github.com/Kilemonn
+ */
+class CreateMessage
+{
+    @Schema(title = "Sub-queue identifier", example = "my-queue-name",
+        description = "The sub-queue identifier for the sub-queue that this message is stored in.")
+    @NotBlank
+    lateinit var subQueue: String
+
+    @Schema(title = "Assignee identifier", example = "owner-id",
+        description = "The unique identifier of assignee who currently possessions or owns this message.")
+    var assignedTo: String? = null
+
+    @Schema(description = "The message payload, this can be any type of complex or simple object that you wish.")
+    var payload: Any? = null
+}

--- a/src/test/kotlin/au/kilemon/messagequeue/message/QueueMessageTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/message/QueueMessageTest.kt
@@ -1,5 +1,6 @@
 package au.kilemon.messagequeue.message
 
+import au.kilemon.messagequeue.rest.controller.model.CreateMessage
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.springframework.util.SerializationUtils
@@ -224,5 +225,54 @@ class QueueMessageTest
         message.resolvePayloadObject()
         Assertions.assertArrayEquals(SerializationUtils.serialize(payload), message.payloadBytes)
         Assertions.assertEquals(payload, message.payload)
+    }
+
+    /**
+     * Ensure the conversion from a [QueueMessageDocument] object sets the correct properties.
+     */
+    @Test
+    fun testFromQueueMessageDocument()
+    {
+        val subQueue = "testFromCreateMessage"
+        val payload = "data"
+        val assignedTo = "assignedTo"
+
+        val queueMessageDocument = QueueMessageDocument()
+        queueMessageDocument.subQueue = subQueue
+        queueMessageDocument.assignedTo = assignedTo
+        queueMessageDocument.payload = payload
+
+        val queueMessage = QueueMessage(queueMessageDocument)
+        Assertions.assertEquals(queueMessageDocument.payload, queueMessage.payload)
+        Assertions.assertEquals(queueMessageDocument.subQueue, queueMessage.subQueue)
+        Assertions.assertEquals(queueMessageDocument.assignedTo, queueMessage.assignedTo)
+        Assertions.assertEquals(queueMessageDocument.uuid, queueMessage.uuid)
+
+        Assertions.assertNotNull(queueMessage.payloadBytes)
+    }
+
+    /**
+     * Ensure the conversion from a [CreateMessage] object sets the correct properties.
+     */
+    @Test
+    fun testFromCreateMessage()
+    {
+        val subQueue = "testFromCreateMessage"
+        val payload = "data"
+        val assignedTo = "assignedTo"
+
+        val createMessage = CreateMessage()
+        createMessage.subQueue = subQueue
+        createMessage.payload = payload
+        createMessage.assignedTo = assignedTo
+
+        val queueMessage = QueueMessage(createMessage)
+
+        Assertions.assertEquals(createMessage.subQueue, queueMessage.subQueue)
+        Assertions.assertEquals(createMessage.payload, queueMessage.payload)
+        Assertions.assertEquals(createMessage.assignedTo, queueMessage.assignedTo)
+
+        Assertions.assertNotNull(queueMessage.payloadBytes)
+        Assertions.assertNotNull(queueMessage.uuid)
     }
 }

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/MultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/MultiQueueTest.kt
@@ -7,8 +7,6 @@ import au.kilemon.messagequeue.queue.exception.DuplicateMessageException
 import au.kilemon.messagequeue.queue.exception.IllegalSubQueueIdentifierException
 import au.kilemon.messagequeue.queue.exception.MessageUpdateException
 import au.kilemon.messagequeue.queue.inmemory.InMemoryMultiQueue
-import au.kilemon.messagequeue.queue.nosql.mongo.MongoMultiQueue
-import au.kilemon.messagequeue.queue.sql.SqlMultiQueue
 import au.kilemon.messagequeue.rest.model.Payload
 import au.kilemon.messagequeue.rest.model.PayloadEnum
 import au.kilemon.messagequeue.settings.MessageQueueSettings
@@ -26,7 +24,6 @@ import org.springframework.context.annotation.Lazy
 import java.io.Serializable
 import java.util.Optional
 import java.util.UUID
-
 import java.util.function.Supplier
 import java.util.stream.Stream
 
@@ -243,87 +240,6 @@ abstract class MultiQueueTest
     }
 
     /**
-     * Ensuring that only the [InMemoryMultiQueue] will auto increment the index as its retrieved but others will not
-     * and [SqlMultiQueue] will always return [Optional.empty].
-     */
-    @Test
-    fun testGetNextQueueIndex_doesNotIncrement()
-    {
-        val subQueue = "testGetNextQueueIndex_doesNotIncrement"
-        if (multiQueue is SqlMultiQueue)
-        {
-            Assertions.assertTrue(multiQueue.getNextSubQueueIndex(subQueue).isEmpty)
-        }
-        else if (multiQueue is InMemoryMultiQueue)
-        {
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(2, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(3, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(4, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(5, multiQueue.getNextSubQueueIndex(subQueue).get())
-
-            multiQueue.clearSubQueue(subQueue)
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(2, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(3, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(4, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(5, multiQueue.getNextSubQueueIndex(subQueue).get())
-
-            multiQueue.clear()
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(2, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(3, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(4, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(5, multiQueue.getNextSubQueueIndex(subQueue).get())
-        }
-        else
-        {
-            Assertions.assertTrue(multiQueue.getNextSubQueueIndex(subQueue).isPresent)
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-            Assertions.assertEquals(1, multiQueue.getNextSubQueueIndex(subQueue).get())
-        }
-    }
-
-    /**
-     * Ensure that [MultiQueue.getNextSubQueueIndex] starts at `1` and increments properly as called once entries are added.
-     */
-    @Test
-    fun testGetNextQueueIndex_withMessages()
-    {
-        Assertions.assertTrue(multiQueue.isEmpty())
-
-        val subQueue1 = "testGetNextQueueIndex_reInitialise1"
-        val subQueue2 = "testGetNextQueueIndex_reInitialise2"
-
-        val list1 = listOf(QueueMessage(81273648, subQueue1), QueueMessage("test test test", subQueue1), QueueMessage(false, subQueue1))
-        val list2 = listOf(QueueMessage("test", subQueue2), QueueMessage(123, subQueue2))
-        Assertions.assertTrue(multiQueue.addAll(list1))
-        Assertions.assertTrue(multiQueue.addAll(list2))
-
-        if (multiQueue is SqlMultiQueue)
-        {
-            Assertions.assertTrue(multiQueue.getNextSubQueueIndex(subQueue1).isEmpty)
-            Assertions.assertTrue(multiQueue.getNextSubQueueIndex(subQueue2).isEmpty)
-        }
-        else if (multiQueue is InMemoryMultiQueue)
-        {
-            Assertions.assertEquals((list1.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue1).get())
-            Assertions.assertEquals((list2.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue2).get())
-        }
-        else if (multiQueue is MongoMultiQueue)
-        {
-            Assertions.assertEquals((list1.size + list2.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue1).get())
-            Assertions.assertEquals((list1.size + list2.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue2).get())
-        }
-        else
-        {
-            Assertions.assertEquals((list1.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue1).get())
-            Assertions.assertEquals((list2.size + 1).toLong(), multiQueue.getNextSubQueueIndex(subQueue2).get())
-        }
-    }
-
-    /**
      * Ensure [MultiQueue.getSubQueue] returns the list of [QueueMessage]s always ordered by their [QueueMessage.id].
      *
      * This also ensures they are assigned the `id` in the order they are enqueued.
@@ -338,18 +254,14 @@ abstract class MultiQueueTest
         Assertions.assertTrue(multiQueue.addAll(list))
         val queue = multiQueue.getSubQueue(subQueue)
         Assertions.assertEquals(list.size, queue.size)
-        var previousIndex: Long? = null
-        list.zip(queue).forEach { pair ->
-            Assertions.assertEquals(pair.first.uuid, pair.second.uuid)
-            Assertions.assertNotNull(pair.second.id)
-            if (previousIndex == null)
+        var previousUuid: String? = null
+        queue.forEach { message ->
+            if (previousUuid != null)
             {
-                previousIndex = pair.second.id
+                Assertions.assertTrue(previousUuid.compareTo(message.uuid) < 0)
             }
-            else
-            {
-                Assertions.assertTrue(previousIndex < pair.second.id!!)
-            }
+
+            previousUuid = message.uuid
         }
     }
 
@@ -378,19 +290,14 @@ abstract class MultiQueueTest
         multiQueue.persistMessage(firstMessage)
 
         queue = multiQueue.getSubQueue(subQueue)
-        var previousIndex: Long? = null
-        list.zip(queue).forEach { pair ->
-            Assertions.assertEquals(pair.first.uuid, pair.second.uuid)
-            Assertions.assertNotNull(pair.second.id)
-            if (previousIndex == null)
+        var previousUuid: String? = null
+        queue.forEach { message ->
+            if (previousUuid != null)
             {
-                Assertions.assertEquals(newData, pair.second.payload)
-                previousIndex = pair.second.id
+                Assertions.assertTrue(previousUuid.compareTo(message.uuid) < 0)
             }
-            else
-            {
-                Assertions.assertTrue(previousIndex < pair.second.id!!)
-            }
+
+            previousUuid = message.uuid
         }
     }
 
@@ -612,10 +519,10 @@ abstract class MultiQueueTest
      * A [MessageUpdateException] will be thrown for all [MultiQueue] except the [InMemoryMultiQueue].
      */
     @Test
-    fun testPersistMessage_messageHasNullID()
+    fun testPersistMessage_messageDoesNotExistToUpdate()
     {
         val message = QueueMessage("payload", "testPersistMessage_messageHasNullID")
-        Assertions.assertNull(message.id)
+        Assertions.assertTrue(multiQueue.getMessageByUUID(message.uuid).isEmpty)
 
         if (multiQueue !is InMemoryMultiQueue)
         {

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
@@ -9,6 +9,8 @@ import au.kilemon.messagequeue.filter.JwtAuthenticationFilter
 import au.kilemon.messagequeue.logging.LoggingConfiguration
 import au.kilemon.messagequeue.message.QueueMessage
 import au.kilemon.messagequeue.queue.MultiQueue
+import au.kilemon.messagequeue.queue.exception.DuplicateMessageException
+import au.kilemon.messagequeue.rest.controller.model.CreateMessage
 import au.kilemon.messagequeue.rest.model.Payload
 import au.kilemon.messagequeue.rest.model.PayloadEnum
 import au.kilemon.messagequeue.rest.response.KeysResponse
@@ -16,6 +18,7 @@ import au.kilemon.messagequeue.rest.response.MessageListResponse
 import au.kilemon.messagequeue.rest.response.MessageResponse
 import au.kilemon.messagequeue.rest.response.OwnersMapResponse
 import au.kilemon.messagequeue.settings.MessageQueueSettings
+import au.kilemon.messagequeue.util.MockUtil
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import org.junit.jupiter.api.Assertions
@@ -30,12 +33,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import java.util.Optional
 import java.util.UUID
 
 /**
@@ -51,6 +56,7 @@ import java.util.UUID
         "${MessageQueueSettings.ACCESS_TOKEN_KEY}=1234567890123456"
     ])
 @Import(*[QueueConfiguration::class, LoggingConfiguration::class])
+@DirtiesContext(methodMode = DirtiesContext.MethodMode.BEFORE_METHOD)
 class MessageQueueControllerTest
 {
     /**
@@ -112,8 +118,8 @@ class MessageQueueControllerTest
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().json("0"))
 
-        val message = createQueueMessage(subQueue = subQueue)
-        Assertions.assertTrue(multiQueue.add(message))
+        val message = createCreateMessage(subQueue = subQueue)
+        Assertions.assertTrue(multiQueue.add(QueueMessage(message)))
         Assertions.assertEquals(1, multiQueue.getSubQueue(subQueue).size)
 
         mockMvc.perform(MockMvcRequestBuilders.get(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_TYPE + "/" + subQueue)
@@ -136,11 +142,11 @@ class MessageQueueControllerTest
             .andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.content().json("0"))
 
-        val message = createQueueMessage(subQueue = "testGetAllSubQueueInfo1")
-        val message2 = createQueueMessage(subQueue = "testGetAllSubQueueInfo2")
+        val message = createCreateMessage(subQueue = "testGetAllSubQueueInfo1")
+        val message2 = createCreateMessage(subQueue = "testGetAllSubQueueInfo2")
 
-        Assertions.assertTrue(multiQueue.add(message))
-        Assertions.assertTrue(multiQueue.add(message2))
+        Assertions.assertTrue(multiQueue.add(QueueMessage(message)))
+        Assertions.assertTrue(multiQueue.add(QueueMessage(message2)))
 
         Assertions.assertEquals(1, multiQueue.getSubQueue(message.subQueue).size)
         Assertions.assertEquals(1, multiQueue.getSubQueue(message2.subQueue).size)
@@ -161,8 +167,9 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testGetEntry")
+        val createMessage = createCreateMessage(subQueue = "testGetEntry")
 
+        val message = QueueMessage(createMessage)
         Assertions.assertTrue(multiQueue.add(message))
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.get(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY + "/" + message.uuid)
@@ -179,7 +186,6 @@ class MessageQueueControllerTest
         Assertions.assertNotNull(messageResponse.message.uuid)
 
         Assertions.assertNull(messageResponse.message.payloadBytes)
-        Assertions.assertNull(messageResponse.message.id)
     }
 
     /**
@@ -265,7 +271,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCreateQueueEntry_withProvidedDefaults", assignedTo = "user-1")
+        val message = createCreateMessage(subQueue = "testCreateQueueEntry_withProvidedDefaults", assignedTo = "user-1")
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -279,12 +285,12 @@ class MessageQueueControllerTest
         Assertions.assertEquals(message.payload, deserialisedPayload)
         Assertions.assertEquals(message.assignedTo, messageResponse.message.assignedTo)
         Assertions.assertEquals(message.subQueue, messageResponse.message.subQueue)
-        Assertions.assertEquals(message.uuid, messageResponse.message.uuid)
+        Assertions.assertNotNull(messageResponse.message.uuid)
 
         val createdMessage = multiQueue.peekSubQueue(message.subQueue).get()
         Assertions.assertEquals(message.assignedTo, createdMessage.assignedTo)
         Assertions.assertEquals(message.subQueue, createdMessage.subQueue)
-        Assertions.assertEquals(message.uuid, createdMessage.uuid)
+        Assertions.assertNotNull(createdMessage.uuid)
     }
 
     /**
@@ -296,7 +302,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCreateQueueEntry_withOutDefaults")
+        val message = createCreateMessage(subQueue = "testCreateQueueEntry_withOutDefaults")
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -315,7 +321,7 @@ class MessageQueueControllerTest
         val createdMessage = multiQueue.peekSubQueue(message.subQueue).get()
         Assertions.assertNull(createdMessage.assignedTo)
         Assertions.assertEquals(message.subQueue, createdMessage.subQueue)
-        Assertions.assertEquals(message.uuid, createdMessage.uuid)
+        Assertions.assertNotNull(createdMessage.uuid)
     }
 
     /**
@@ -327,9 +333,10 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCreateEntry_Conflict")
+        val message = createCreateMessage(subQueue = "testCreateEntry_Conflict")
 
-        Assertions.assertTrue(multiQueue.add(message))
+        Mockito.doThrow(DuplicateMessageException("", "")).`when`(multiQueue).add(MockUtil.any())
+        Mockito.doReturn(Optional.of(message.subQueue)).`when`(multiQueue).containsUUID(Mockito.anyString())
 
         mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -346,7 +353,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCreateQueueEntry_withAssignedButNoAssignedTo")
+        val message = createCreateMessage(subQueue = "testCreateQueueEntry_withAssignedButNoAssignedTo")
         message.assignedTo = " "
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
@@ -369,7 +376,7 @@ class MessageQueueControllerTest
         Mockito.doReturn(RestrictionMode.HYBRID).`when`(authenticator).getRestrictionMode()
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCreateEntry_inHybridMode")
+        val message = createCreateMessage(subQueue = "testCreateEntry_inHybridMode")
 
         Assertions.assertTrue(authenticator.addRestrictedEntry(message.subQueue))
         Assertions.assertTrue(authenticator.isRestricted(message.subQueue))
@@ -388,7 +395,7 @@ class MessageQueueControllerTest
             .content(gson.toJson(message)))
             .andExpect(MockMvcResultMatchers.status().isCreated)
 
-        val message2 = createQueueMessage(subQueue = "testCreateEntry_inHybridMode2")
+        val message2 = createCreateMessage(subQueue = "testCreateEntry_inHybridMode2")
         Assertions.assertFalse(authenticator.isRestricted(message2.subQueue))
 
         mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
@@ -531,8 +538,8 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val subQueue = "testGetAll_inHybridMode"
-        val messages = listOf(createQueueMessage(subQueue), createQueueMessage(subQueue))
-        messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
+        val messages = listOf(createCreateMessage(subQueue), createCreateMessage(subQueue))
+        messages.forEach { message -> Assertions.assertTrue(multiQueue.add(QueueMessage(message))) }
 
         Assertions.assertTrue(authenticator.addRestrictedEntry(subQueue))
         Assertions.assertTrue(authenticator.isRestricted(subQueue))
@@ -584,8 +591,8 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val subQueue = "testGetAll_SpecificSubQueue_inHybridMode"
-        val messages = listOf(createQueueMessage(subQueue), createQueueMessage(subQueue))
-        messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
+        val messages = listOf(createCreateMessage(subQueue), createCreateMessage(subQueue))
+        messages.forEach { message -> Assertions.assertTrue(multiQueue.add(QueueMessage(message))) }
 
         Assertions.assertTrue(authenticator.addRestrictedEntry(subQueue))
         Assertions.assertTrue(authenticator.isRestricted(subQueue))
@@ -649,8 +656,8 @@ class MessageQueueControllerTest
 
         val assignedTo = "my-assigned-to-identifier"
         val subQueue = "testGetOwned_SomeOwned"
-        val message1 = createQueueMessage(assignedTo = assignedTo, subQueue = subQueue)
-        val message2 = createQueueMessage(assignedTo = assignedTo, subQueue = subQueue)
+        val message1 = QueueMessage(createCreateMessage(assignedTo = assignedTo, subQueue = subQueue))
+        val message2 = QueueMessage(createCreateMessage(assignedTo = assignedTo, subQueue = subQueue))
 
         Assertions.assertTrue(multiQueue.add(message1))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -683,8 +690,8 @@ class MessageQueueControllerTest
 
         val assignedTo = "my-assigned-to-identifier"
         val subQueue = "testGetOwned_SomeOwned_inHybridMode"
-        val message1 = createQueueMessage(assignedTo = assignedTo, subQueue = subQueue)
-        val message2 = createQueueMessage(assignedTo = assignedTo, subQueue = subQueue)
+        val message1 = QueueMessage(createCreateMessage(assignedTo = assignedTo, subQueue = subQueue))
+        val message2 = QueueMessage(createCreateMessage(assignedTo = assignedTo, subQueue = subQueue))
 
         Assertions.assertTrue(multiQueue.add(message1))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -745,7 +752,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assigned"
-        val message = createQueueMessage(subQueue = "testAssignMessage_messageIsAssigned")
+        val message = QueueMessage(createCreateMessage(subQueue = "testAssignMessage_messageIsAssigned"))
         Assertions.assertNull(message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
 
@@ -775,7 +782,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assigned"
-        val message = createQueueMessage(subQueue = "testAssignMessage_messageIsAssigned_inHybridMode")
+        val message = QueueMessage(createCreateMessage(subQueue = "testAssignMessage_messageIsAssigned_inHybridMode"))
         Assertions.assertNull(message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
 
@@ -817,7 +824,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assigned"
-        val message = createQueueMessage(subQueue = "testAssignMessage_alreadyAssignedToSameID", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testAssignMessage_alreadyAssignedToSameID", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -847,7 +854,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assignee"
-        val message = createQueueMessage(subQueue = "testAssignMessage_alreadyAssignedToOtherID", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testAssignMessage_alreadyAssignedToOtherID", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -900,8 +907,8 @@ class MessageQueueControllerTest
 
         val assignedTo = "assignee"
         val subQueue = "testGetNext_noNewUnAssignedMessages"
-        val message = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
-        val message2 = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -926,8 +933,8 @@ class MessageQueueControllerTest
 
         val assignedTo = "assignee"
         val subQueue = "testGetNext"
-        val message = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
-        val message2 = createQueueMessage(subQueue = subQueue)
+        val message = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueue))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -964,8 +971,8 @@ class MessageQueueControllerTest
 
         val assignedTo = "assignee"
         val subQueue = "testGetNext_inHybridMode"
-        val message = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
-        val message2 = createQueueMessage(subQueue = subQueue)
+        val message = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueue))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -1028,7 +1035,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assignee"
-        val message = createQueueMessage(subQueue = "testReleaseMessage_messageIsReleased", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testReleaseMessage_messageIsReleased", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -1059,7 +1066,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assignee"
-        val message = createQueueMessage(subQueue = "testReleaseMessage_messageIsReleased_inHybridMode", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testReleaseMessage_messageIsReleased_inHybridMode", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -1102,7 +1109,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assigned"
-        val message = createQueueMessage(subQueue = "testReleaseMessage_messageIsReleased_withoutAssignedToInQuery", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testReleaseMessage_messageIsReleased_withoutAssignedToInQuery", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -1130,7 +1137,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testReleaseMessage_alreadyReleased")
+        val message = QueueMessage(createCreateMessage(subQueue = "testReleaseMessage_alreadyReleased"))
         Assertions.assertNull(message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
 
@@ -1160,7 +1167,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assigned"
-        val message = createQueueMessage(subQueue = "testReleaseMessage_cannotBeReleasedWithMisMatchingID", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testReleaseMessage_cannotBeReleasedWithMisMatchingID", assignedTo = assignedTo))
 
         Assertions.assertEquals(assignedTo, message.assignedTo)
         Assertions.assertTrue(multiQueue.add(message))
@@ -1200,7 +1207,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testRemoveMessage_removed")
+        val message = QueueMessage(createCreateMessage(subQueue = "testRemoveMessage_removed"))
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.containsUUID(message.uuid).isPresent)
 
@@ -1222,7 +1229,7 @@ class MessageQueueControllerTest
         Mockito.doReturn(RestrictionMode.HYBRID).`when`(authenticator).getRestrictionMode()
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testRemoveMessage_removeExistingEntry_inHybridMode")
+        val message = QueueMessage(createCreateMessage(subQueue = "testRemoveMessage_removeExistingEntry_inHybridMode"))
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.containsUUID(message.uuid).isPresent)
 
@@ -1274,7 +1281,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assignee"
-        val message = createQueueMessage(subQueue = "testRemoveMessage_assignedToAnotherID", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testRemoveMessage_assignedToAnotherID", assignedTo = assignedTo))
         Assertions.assertTrue(multiQueue.add(message))
 
         val wrongAssignedTo = "wrong-assignee"
@@ -1301,9 +1308,9 @@ class MessageQueueControllerTest
 
         val subQueue = "testGetOwners"
 
-        val message = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
-        val message2 = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo2)
-        val message3 = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo2)
+        val message = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo2))
+        val message3 = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo2))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -1345,9 +1352,9 @@ class MessageQueueControllerTest
         val subQueue = "testGetOwners"
         val subQueue2 = "testGetOwners2"
 
-        val message = createQueueMessage(subQueue = subQueue, assignedTo = assignedTo)
-        val message2 = createQueueMessage(subQueue = subQueue2, assignedTo = assignedTo)
-        val message3 = createQueueMessage(subQueue = subQueue2, assignedTo = assignedTo2)
+        val message = QueueMessage(createCreateMessage(subQueue = subQueue, assignedTo = assignedTo))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueue2, assignedTo = assignedTo))
+        val message3 = QueueMessage(createCreateMessage(subQueue = subQueue2, assignedTo = assignedTo2))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -1398,7 +1405,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCorrelationId_providedId")
+        val message = createCreateMessage(subQueue = "testCorrelationId_providedId")
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -1419,7 +1426,7 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = createQueueMessage(subQueue = "testCorrelationId_providedId")
+        val message = createCreateMessage(subQueue = "testCorrelationId_providedId")
         val correlationId = "my-correlation-id-123456"
 
         val mvcResult: MvcResult = mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
@@ -1444,7 +1451,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val assignedTo = "assignee"
-        val message = createQueueMessage(subQueue = "testCorrelationId_randomIdOnError", assignedTo = assignedTo)
+        val message = QueueMessage(createCreateMessage(subQueue = "testCorrelationId_randomIdOnError", assignedTo = assignedTo))
         Assertions.assertTrue(multiQueue.add(message))
 
         val wrongAssignedTo = "wrong-assignee"
@@ -1476,13 +1483,16 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val subQueue1 = "testDeleteKeys_singleKey1"
-        var messages = listOf(createQueueMessage(subQueue1), createQueueMessage(subQueue1), createQueueMessage(subQueue1))
+        var messages = listOf(QueueMessage(createCreateMessage(subQueue1)),
+            QueueMessage(createCreateMessage(subQueue1)),
+            QueueMessage(createCreateMessage(subQueue1)))
         messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
 
         Assertions.assertEquals(3, multiQueue.size)
 
         val subQueue2 = "testDeleteKeys_singleKey2"
-        messages = listOf(createQueueMessage(subQueue2), createQueueMessage(subQueue2))
+        messages = listOf(QueueMessage(createCreateMessage(subQueue2)),
+            QueueMessage(createCreateMessage(subQueue2)))
         messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
 
         Assertions.assertEquals(5, multiQueue.size)
@@ -1511,13 +1521,16 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
         val subQueue1 = "testDeleteKeys_singleKey_inHybridMode1"
-        var messages = listOf(createQueueMessage(subQueue1), createQueueMessage(subQueue1), createQueueMessage(subQueue1))
+        var messages = listOf(QueueMessage(createCreateMessage(subQueue1)),
+            QueueMessage(createCreateMessage(subQueue1)),
+            QueueMessage(createCreateMessage(subQueue1)))
         messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
 
         Assertions.assertEquals(3, multiQueue.size)
 
         val subQueue2 = "testDeleteKeys_singleKey_inHybridMode2"
-        messages = listOf(createQueueMessage(subQueue2), createQueueMessage(subQueue2))
+        messages = listOf(QueueMessage(createCreateMessage(subQueue2)),
+            QueueMessage(createCreateMessage(subQueue2)))
         messages.forEach { message -> Assertions.assertTrue(multiQueue.add(message)) }
 
         Assertions.assertEquals(5, multiQueue.size)
@@ -1643,9 +1656,9 @@ class MessageQueueControllerTest
     {
         Assertions.assertEquals(RestrictionMode.HYBRID, authenticator.getRestrictionMode())
 
-        val message = QueueMessage("payload", "testCreateMessage_addFails")
+        val message = createCreateMessage("testCreateMessage_addFails")
 
-        Mockito.doReturn(false).`when`(multiQueue).add(message)
+        Mockito.doReturn(false).`when`(multiQueue).add(MockUtil.any())
 
         mockMvc.perform(MockMvcRequestBuilders.post(MessageQueueController.MESSAGE_QUEUE_BASE_PATH + "/" + MessageQueueController.ENDPOINT_ENTRY)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -1709,7 +1722,7 @@ class MessageQueueControllerTest
         Assertions.assertEquals(RestrictionMode.RESTRICTED, authenticator.getRestrictionMode())
 
         val subQueue = "testGetEntry_inRestrictedMode"
-        val message = createQueueMessage(subQueue)
+        val message = QueueMessage(createCreateMessage(subQueue))
 
         Assertions.assertTrue(multiQueue.add(message))
 
@@ -1735,17 +1748,17 @@ class MessageQueueControllerTest
     }
 
     /**
-     * A helper method which creates `4` [QueueMessage] objects and inserts them into the [MultiQueue].
+     * A helper method which creates `4` [CreateMessage] objects and inserts them into the [MultiQueue].
      *
      * @return a [Pair] containing the [List] of [QueueMessage] and their related matching [List] of [String] `sub-queue` IDs in order.
      */
     private fun initialiseMapWithEntries(): Pair<List<QueueMessage>, List<String>>
     {
         val subQueues = listOf("type1", "type2", "type3", "type4")
-        val message = createQueueMessage(subQueue = subQueues[0])
-        val message2 = createQueueMessage(subQueue = subQueues[1])
-        val message3 = createQueueMessage(subQueue = subQueues[2], assignedTo = "assignee")
-        val message4 = createQueueMessage(subQueue = subQueues[3])
+        val message = QueueMessage(createCreateMessage(subQueue = subQueues[0]))
+        val message2 = QueueMessage(createCreateMessage(subQueue = subQueues[1]))
+        val message3 = QueueMessage(createCreateMessage(subQueue = subQueues[2], assignedTo = "assignee"))
+        val message4 = QueueMessage(createCreateMessage(subQueue = subQueues[3]))
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
@@ -1756,18 +1769,18 @@ class MessageQueueControllerTest
     }
 
     /**
-     * A helper method to create a [QueueMessage] that can be easily re-used between each test.
+     * A helper method to create a [CreateMessage] that can be easily re-used between each test.
      *
-     * @param subQueue the `subQueue` to set in to the created [QueueMessage]
+     * @param subQueue the `subQueue` to set in to the created [CreateMessage]
      * @param assignedTo the [QueueMessage.assignedTo] value to set
-     * @return a [QueueMessage] initialised with multiple parameters
+     * @return a [CreateMessage] initialised with multiple parameters
      */
-    private fun createQueueMessage(subQueue: String, assignedTo: String? = null): QueueMessage
+    private fun createCreateMessage(subQueue: String, assignedTo: String? = null): CreateMessage
     {
-        val uuid = UUID.randomUUID().toString()
         val payload = Payload("test", 12, true, PayloadEnum.C)
-        val message = QueueMessage(payload = payload, subQueue = subQueue)
-        message.uuid = UUID.fromString(uuid).toString()
+        val message = CreateMessage()
+        message.subQueue = subQueue
+        message.payload = payload
 
         message.assignedTo = assignedTo
         return message

--- a/src/test/kotlin/au/kilemon/messagequeue/util/MockUtil.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/util/MockUtil.kt
@@ -1,0 +1,26 @@
+package au.kilemon.messagequeue.util
+
+import org.mockito.Mockito
+
+/**
+ * MockUtil class to help with any specific mocking workarounds in tests.
+ *
+ * @author github.com/Kilemonn
+ */
+class MockUtil
+{
+    companion object
+    {
+        /**
+         * Helper method to return [Mockito.any] as a non-null type [T].
+         * This is required for Kotlin to mock non-nullable parameters.
+         */
+        fun <T> any(): T
+        {
+            Mockito.any<T>()
+            return uninitialized()
+        }
+
+        private fun <T> uninitialized(): T = null as T
+    }
+}


### PR DESCRIPTION
- Uses UUID v7 which are generated using the current time such that the UUID can be lexicographically sorted, instead of using a traditional DB ID to remove any ID sequencing logic.
- Adds new CreateMessage model to prevent the caller from setting the UUID, we will always set it so its always a v7 UUID and its order can be set correctly.