### PR TITLE
Improve restriction removal

### DIFF
--- a/.github/workflows/gradle-on-pull-request.yml
+++ b/.github/workflows/gradle-on-pull-request.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Build and test
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build

--- a/.github/workflows/gradle-on-push-to-main.yml
+++ b/.github/workflows/gradle-on-push-to-main.yml
@@ -5,10 +5,12 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: CI Build
+name: Build, test and update coverage badge
 
 on:
   push:
+    branches: [ "main" ]
+  pull_request:
     branches: [ "main" ]
 
 permissions:

--- a/.github/workflows/gradle-on-push-to-main.yml
+++ b/.github/workflows/gradle-on-push-to-main.yml
@@ -10,8 +10,6 @@ name: Build, test and update coverage badge
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: write

--- a/src/main/kotlin/au/kilemon/messagequeue/rest/controller/AuthController.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/rest/controller/AuthController.kt
@@ -139,24 +139,18 @@ open class AuthController : HasLogger
         {
             if (multiQueueAuthenticator.isRestricted(subQueue))
             {
-                return if (multiQueueAuthenticator.removeRestriction(subQueue))
+                if (clearQueue == true)
                 {
-                    if (clearQueue == true)
-                    {
-                        LOG.info("Restriction removed and clearing sub-queue [{}].", subQueue)
-                        multiQueue.clearSubQueue(subQueue)
-                    }
-                    else
-                    {
-                        LOG.info("Removed restriction from sub-queue [{}] without clearing stored messages.", subQueue)
-                    }
-                    ResponseEntity.ok().build()
+                    LOG.info("Removing restriction and clearing sub-queue [{}].", subQueue)
+                    multiQueue.clearSubQueue(subQueue)
                 }
                 else
                 {
-                    LOG.error("Failed to remove restriction for sub-queue [{}].", subQueue)
-                    ResponseEntity.internalServerError().build()
+                    LOG.info("Removing restriction from sub-queue [{}] without clearing stored messages.", subQueue)
                 }
+
+                multiQueueAuthenticator.removeRestriction(subQueue)
+                return ResponseEntity.ok().build()
             }
             else
             {

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/AuthControllerTest.kt
@@ -286,33 +286,6 @@ class AuthControllerTest
     }
 
     /**
-     * Ensure [AuthController.removeRestrictionFromSubQueue] returns
-     * [org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR] when there is an error when attempting to remove
-     * the restriction on the sub-queue.
-     */
-    @Test
-    fun testRemoveRestrictionFromSubQueue_failedToRemoveRestriction()
-    {
-        Mockito.doReturn(RestrictionMode.HYBRID).`when`(multiQueueAuthenticator).getRestrictionMode()
-        Assertions.assertEquals(RestrictionMode.HYBRID, multiQueueAuthenticator.getRestrictionMode())
-
-        val subQueue = "testRemoveRestrictionFromSubQueue_failedToRemoveRestriction"
-        val token = jwtTokenProvider.createTokenForSubQueue(subQueue)
-        Assertions.assertTrue(token.isPresent)
-
-        Assertions.assertTrue(multiQueueAuthenticator.addRestrictedEntry(subQueue))
-        Assertions.assertTrue(multiQueueAuthenticator.isRestricted(subQueue))
-
-        Mockito.doReturn(false).`when`(multiQueueAuthenticator).removeRestriction(subQueue)
-
-        mockMvc.perform(
-            MockMvcRequestBuilders.delete("${AuthController.AUTH_PATH}/${subQueue}")
-                .header(JwtAuthenticationFilter.AUTHORIZATION_HEADER, "${JwtAuthenticationFilter.BEARER_HEADER_VALUE}${token.get()}")
-                .contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(MockMvcResultMatchers.status().isInternalServerError)
-    }
-
-    /**
      * Ensure [AuthController.removeRestrictionFromSubQueue] returns [org.springframework.http.HttpStatus.OK] when
      * the sub-queue restriction is removed BUT the sub-queue is not cleared when the query parameter
      * [RestParameters.CLEAR_QUEUE] is not provided.


### PR DESCRIPTION
- When removing a sub queue restriction, if the user also requests for the sub queue to be cleared as part of the restriction removal: clear the queue first then remove the restriction to prevent any situation where another caller is able to see "restricted" queue messages that should not be available.